### PR TITLE
Refactor embedding layer and fix training utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ nqe/
 The modules can be imported as a package:
 
 ```python
-from nqe import NQE, QLayer, ZZFeatureMap, train_with_early_stopping
+from nqe import NQE, QuantumEmbeddingLayer, ZZFeatureMap, train_with_early_stopping
 ```
 
 The code requires PyTorch, PennyLane and the usual scientific Python stack.

--- a/nqe/__init__.py
+++ b/nqe/__init__.py
@@ -1,4 +1,4 @@
-from .embedding import QLayer, ZZFeatureMap, make_qml_device
+from .embedding import QuantumEmbeddingLayer, QLayer, ZZFeatureMap, make_qml_device
 from .models import (Stacking, NQE, NQE_BIG, NQE_repeat, UpConvolution1,
                      UpConvolution2, UCNQE, QCNN, Ansatz)
 from .data import (load_mnist_pca, load_fashion_mnist_pca,

--- a/nqe/embedding.py
+++ b/nqe/embedding.py
@@ -28,7 +28,15 @@ def make_qml_device(n_wires, shots=None):
         return qml.device("default.qubit", wires=n_wires, shots=shots)
 
 
-class QLayer:
+class QuantumEmbeddingLayer:
+    """Wrap a feature embedding circuit in PennyLane QNodes.
+
+    The layer exposes QNodes for training with probability outputs and for
+    generating density matrices.  A helper ``_embedding`` method applies the
+    embedding circuit without returning a value, which is useful when composing
+    with additional circuits.
+    """
+
     def __init__(self, embedding, *, n_qubits, dev=None):
         self.embedding = embedding
         self.n_qubits = n_qubits
@@ -68,6 +76,7 @@ class QLayer:
                     x[:, :, i], wires=range(n_qubits),
                     rot_factor=2.0 / n_layers, ent_factor=2.0 / n_layers,
                 )
+            # No return value: this is used for side-effect state preparation.
 
         self._train_qnode = qml.QNode(_train, self.dev, interface="torch")
         self._dm_qnode = qml.QNode(_dm, self.dev, interface="torch")
@@ -78,3 +87,7 @@ class QLayer:
 
     def dm_layer(self, x):
         return self._dm_qnode(x)
+
+
+# Backward compatibility
+QLayer = QuantumEmbeddingLayer

--- a/nqe/models.py
+++ b/nqe/models.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 from itertools import pairwise
 import pennylane as qml
-from .embedding import QLayer
+from .embedding import QuantumEmbeddingLayer
 from .utils import QFIMTracker
 
 
@@ -18,7 +18,7 @@ class Stacking(nn.Module):
 
 class NQE(nn.Module):
     def __init__(self, in_dims: int, n_qubits: int, n_layers: int,
-                 hidden_dims: int | List[int], q_embedding: QLayer):
+                 hidden_dims: int | List[int], q_embedding: QuantumEmbeddingLayer):
         super().__init__()
         self.in_dims = in_dims
         self.n_qubits = n_qubits
@@ -40,7 +40,7 @@ class NQE(nn.Module):
     def forward(self, x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
         x1 = self.linear(x1)
         x2 = self.linear(x2)
-        x = torch.concat([x1, x2], dim=1)
+        x = torch.cat([x1, x2], dim=1)
         x = self.stacking(x)
         x = self.q_layer(x)
         return x[:, 0]
@@ -51,7 +51,7 @@ NQE_repeat = NQE
 
 class NQE_BIG(nn.Module):
     def __init__(self, in_dims: int, n_qubits: int, n_layers: int,
-                 hidden_dims: Optional[int | List[int]], q_embedding: QLayer):
+                 hidden_dims: Optional[int | List[int]], q_embedding: QuantumEmbeddingLayer):
         super().__init__()
         self.in_dims = in_dims
         self.n_qubits = n_qubits
@@ -72,7 +72,7 @@ class NQE_BIG(nn.Module):
     def forward(self, x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
         x1 = self.linear(x1).reshape(-1, self.n_qubits, self.n_layers)
         x2 = self.linear(x2).reshape(-1, self.n_qubits, self.n_layers)
-        x = torch.concat([x1, x2], dim=1).reshape(x1.size(0), -1)
+        x = torch.cat([x1, x2], dim=1).reshape(x1.size(0), -1)
         x = self.q_layer(x)
         return x[:, 0]
 
@@ -103,7 +103,7 @@ class UpConvolution2(nn.Module):
 
 class UCNQE(nn.Module):
     def __init__(self, in_dims: int, n_qubits: int, n_layers: int,
-                 hidden_dims: Optional[int | List[int]], q_embedding: QLayer,
+                 hidden_dims: Optional[int | List[int]], q_embedding: QuantumEmbeddingLayer,
                  mode: Literal['single', 'block']):
         super().__init__()
         self.in_dims = in_dims
@@ -130,7 +130,7 @@ class UCNQE(nn.Module):
     def forward(self, x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
         x1 = self.up_conv(self.linear(x1))
         x2 = self.up_conv(self.linear(x2))
-        x = torch.concat([x1, x2], dim=1)
+        x = torch.cat([x1, x2], dim=1)
         x = self.q_layer(x)
         return x[:, 0]
 

--- a/nqe/utils.py
+++ b/nqe/utils.py
@@ -1,6 +1,7 @@
 import numpy
 from pennylane import numpy as np
 import torch
+import torch.nn as nn
 import matplotlib.pyplot as plt
 from matplotlib.collections import PolyCollection
 import mpld3
@@ -8,6 +9,7 @@ from mpld3 import plugins
 from typing import Literal
 import pennylane as qml
 
+# Disable automatic JS injection on import.
 mpld3.disable_notebook()
 
 
@@ -197,7 +199,7 @@ class Metric(nn.Module):
         K = torch.real(torch.einsum('bij,cji->bc', rhos, rhos)).to(torch.float32)
         H = torch.eye(B, device=K.device) - torch.ones((B,B), device=K.device) / B
         Kc = H @ K @ H
-        Ky = torch.ger(y, y)
+        Ky = torch.outer(y, y)
         Ky_c = H @ Ky @ H
         num = torch.sum(Kc*Ky_c)
         den = torch.linalg.norm(Kc, 'fro') * torch.linalg.norm(Ky_c, 'fro')


### PR DESCRIPTION
## Summary
- rename `QLayer` to `QuantumEmbeddingLayer` with documentation and backwards-compatible alias
- replace deprecated and ambiguous API usages (e.g. `torch.concat`, `torch.ger`)
- fix missing imports and weight comparison in QCNN training utilities

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bede86c7448325b5806a95fdf00569