### PR TITLE
Add configurable NQE training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,37 @@ from nqe import NQE, QuantumEmbeddingLayer, ZZFeatureMap, train_with_early_stopp
 ```
 
 The code requires PyTorch, PennyLane and the usual scientific Python stack.
+
+## Training script
+
+A convenient CLI is available for training NQE, NQE_BIG or UCNQE models and
+visualising the loss curves.  For example, the following trains a UCNQE model
+with block up-convolution:
+
+```bash
+python scripts/train_nqe.py --model ucnqe --uc-mode block --dataset mnist \
+    --pca-dim 8 --n-qubits 4 --n-layers 2 --hidden-dims 16 16 --max-steps 1000
+```
+
+The `--model` flag selects the architecture (`nqe`, `nqe_big` or `ucnqe`); the
+`--uc-mode` option chooses the up-convolution strategy used by UCNQE models.
+All major hyper-parameters (dataset choice, model size, optimisation settings,
+number of steps, etc.) can be configured through command line flags.  The script
+saves a plot of the training and validation losses.  Pass `--checkpoint FILE` to
+store the final model weights in PyTorch's `.pt` format.
+
+For parameter sweeps, a helper script will train several models in sequence. The
+following command trains NQE, NQE_BIG and both UCNQE variants for one to four
+embedding layers and stores the resulting plots in `bulk_training/`:
+
+```bash
+python scripts/bulk_train.py --layers 1 2 3 4
+```
+
+In addition to individual training curves, `bulk_train.py` writes a
+`comparison.png` plot summarising the best validation loss for each model versus
+the number of layers.  It also evaluates each trained model on the test set and
+produces `trace_distance.png`, `hs_distance.png` and `qka.png` comparing the
+trace distance, Hilbert–Schmidt distance and quantum kernel alignment across
+layer counts.  Supplying `--checkpoint-dir DIR` will save the trained weights for
+every configuration inside `DIR`.

--- a/scripts/bulk_train.py
+++ b/scripts/bulk_train.py
@@ -1,0 +1,160 @@
+import argparse
+from itertools import product
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from train_nqe import train_model, load_dataset
+from nqe.utils import Metric
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Train multiple NQE variants across a range of layer counts"
+    )
+    parser.add_argument(
+        "--dataset", choices=["mnist", "fashion"], default="mnist",
+        help="Dataset to use for all runs",
+    )
+    parser.add_argument("--pca-dim", type=int, default=8, help="Number of PCA components")
+    parser.add_argument("--n-qubits", type=int, default=4, help="Number of qubits")
+    parser.add_argument(
+        "--hidden-dims", type=int, nargs="+", default=[16, 16],
+        help="Dimensions of hidden classical layers",
+    )
+    parser.add_argument("--batch-size", type=int, default=32, help="Training batch size")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument("--max-steps", type=int, default=1000, help="Maximum training steps")
+    parser.add_argument(
+        "--validate-every", type=int, default=25,
+        help="Validate every N training steps",
+    )
+    parser.add_argument("--patience", type=int, default=300, help="Early stopping patience")
+    parser.add_argument("--warm-up", type=int, default=100, help="Early stopping warmup")
+    parser.add_argument(
+        "--no-scheduler", action="store_true", help="Disable learning rate scheduler"
+    )
+    parser.add_argument(
+        "--layers", type=int, nargs="+", default=[1, 2, 3, 4],
+        help="List of layer counts to train",
+    )
+    parser.add_argument(
+        "--models", nargs="+", default=["nqe", "nqe_big", "ucnqe"],
+        choices=["nqe", "nqe_big", "ucnqe"],
+        help="Model variants to train",
+    )
+    parser.add_argument(
+        "--uc-modes", nargs="+", default=["single", "block"],
+        choices=["single", "block"],
+        help="UCNQE up-convolution modes to sweep",
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Training device",
+    )
+    parser.add_argument(
+        "--output-dir", default="bulk_training", help="Directory to store plots",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        default=None,
+        help="Directory to store model checkpoints",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    ckpt_dir = Path(args.checkpoint_dir) if args.checkpoint_dir else None
+    if ckpt_dir:
+        ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # Preload test data for metric evaluation
+    _, _, X_test, Y_test = load_dataset(args.dataset, args.pca_dim)
+    device = torch.device(args.device)
+    X_test_t = torch.as_tensor(X_test, dtype=torch.float32, device=device)
+    Y_test_t = torch.as_tensor(Y_test, dtype=torch.float32, device=device)
+    idx0 = np.where(Y_test == 0)[0]
+    idx1 = np.where(Y_test == 1)[0]
+    X0_t = torch.as_tensor(X_test[idx0], dtype=torch.float32, device=device)
+    X1_t = torch.as_tensor(X_test[idx1], dtype=torch.float32, device=device)
+
+    loss_results = {}
+    tr_results = {}
+    hs_results = {}
+    qka_results = {}
+
+    for model in args.models:
+        modes = args.uc_modes if model == "ucnqe" else ["single"]
+        for uc_mode, n_layers in product(modes, args.layers):
+            suffix = (
+                f"{model}_{uc_mode}_{n_layers}layers"
+                if model == "ucnqe"
+                else f"{model}_{n_layers}layers"
+            )
+            output = out_dir / f"{suffix}.png"
+            checkpoint = str(ckpt_dir / f"{suffix}.pt") if ckpt_dir else None
+            hist, mdl = train_model(
+                dataset=args.dataset,
+                model=model,
+                pca_dim=args.pca_dim,
+                uc_mode=uc_mode,
+                n_qubits=args.n_qubits,
+                n_layers=n_layers,
+                hidden_dims=args.hidden_dims,
+                batch_size=args.batch_size,
+                lr=args.lr,
+                max_steps=args.max_steps,
+                validate_every=args.validate_every,
+                patience=args.patience,
+                warm_up=args.warm_up,
+                use_scheduler=not args.no_scheduler,
+                device=args.device,
+                output=str(output),
+                checkpoint=checkpoint,
+            )
+            label = model.upper() if model != "ucnqe" else f"UCNQE-{uc_mode}"
+            metric = Metric(mdl)
+            tr = float(metric.separability(X0_t, X1_t, "Tr", trained=True).item())
+            hs = float(metric.separability(X0_t, X1_t, "HS", trained=True).item())
+            qka = metric.centered_kernel_alignment(X_test_t, Y_test_t, trained=True)
+            loss_results.setdefault(label, []).append((n_layers, min(hist["val_loss"])))
+            tr_results.setdefault(label, []).append((n_layers, tr))
+            hs_results.setdefault(label, []).append((n_layers, hs))
+            qka_results.setdefault(label, []).append((n_layers, qka))
+            print(
+                f"Finished {suffix} (Tr={tr:.6f}, HS={hs:.6f}, QKA={qka:.6f})"
+            )
+
+    def plot_metric(res_map, ylabel, filename):
+        if not res_map:
+            return
+        plt.figure()
+        for label, data in res_map.items():
+            data.sort(key=lambda x: x[0])
+            layers = [n for n, _ in data]
+            vals = [v for _, v in data]
+            plt.plot(layers, vals, marker="o", label=label)
+        plt.xlabel("embedding layers")
+        plt.ylabel(ylabel)
+        plt.legend()
+        plt.tight_layout()
+        path = out_dir / filename
+        plt.savefig(path)
+        plt.close()
+        print(f"{ylabel} plot saved to {path}")
+
+    plot_metric(loss_results, "best validation loss", "comparison.png")
+    plot_metric(tr_results, "trace distance", "trace_distance.png")
+    plot_metric(hs_results, "HS distance", "hs_distance.png")
+    plot_metric(qka_results, "quantum kernel alignment", "qka.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_nqe.py
+++ b/scripts/train_nqe.py
@@ -1,0 +1,218 @@
+import argparse
+import matplotlib.pyplot as plt
+import torch
+from typing import Optional
+
+from nqe.data import (
+    build_train_loader,
+    build_validation_loader,
+    load_fashion_mnist_pca,
+    load_mnist_pca,
+)
+from nqe.embedding import QuantumEmbeddingLayer, ZZFeatureMap
+from nqe.models import NQE, NQE_BIG, UCNQE
+from nqe.training import train_with_early_stopping
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train an NQE model and plot results")
+    parser.add_argument(
+        "--dataset",
+        choices=["mnist", "fashion"],
+        default="mnist",
+        help="Dataset to use (mnist or fashion)",
+    )
+    parser.add_argument(
+        "--model",
+        choices=["nqe", "nqe_big", "ucnqe"],
+        default="nqe",
+        help="Model variant to train",
+    )
+    parser.add_argument(
+        "--pca-dim", type=int, default=8, help="Number of PCA components"
+    )
+    parser.add_argument(
+        "--uc-mode",
+        choices=["single", "block"],
+        default="single",
+        help="UCNQE up-convolution mode",
+    )
+    parser.add_argument(
+        "--n-qubits", type=int, default=4, help="Number of qubits in the quantum layer"
+    )
+    parser.add_argument(
+        "--n-layers", type=int, default=2, help="Number of embedding layers"
+    )
+    parser.add_argument(
+        "--hidden-dims",
+        type=int,
+        nargs="+",
+        default=[16, 16],
+        help="Dimensions of hidden classical layers",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=32, help="Training batch size"
+    )
+    parser.add_argument(
+        "--lr", type=float, default=1e-3, help="Learning rate"
+    )
+    parser.add_argument(
+        "--max-steps", type=int, default=1000, help="Maximum training steps"
+    )
+    parser.add_argument(
+        "--validate-every",
+        type=int,
+        default=25,
+        help="Validate every N training steps",
+    )
+    parser.add_argument(
+        "--patience", type=int, default=300, help="Early stopping patience"
+    )
+    parser.add_argument(
+        "--warm-up", type=int, default=100, help="Early stopping warmup"
+    )
+    parser.add_argument(
+        "--no-scheduler",
+        action="store_true",
+        help="Disable learning rate scheduler",
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Training device",
+    )
+    parser.add_argument(
+        "--output",
+        default="training.png",
+        help="Where to save the training plot",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        help="Path to save final model weights (.pt)",
+    )
+    return parser.parse_args()
+
+
+def load_dataset(name: str, pca_dim: int):
+    if name == "mnist":
+        return load_mnist_pca(pca_dim)
+    else:
+        return load_fashion_mnist_pca(pca_dim)
+
+
+def train_model(
+    *,
+    dataset: str = "mnist",
+    model: str = "nqe",
+    pca_dim: int = 8,
+    uc_mode: str = "single",
+    n_qubits: int = 4,
+    n_layers: int = 2,
+    hidden_dims=None,
+    batch_size: int = 32,
+    lr: float = 1e-3,
+    max_steps: int = 1000,
+    validate_every: int = 25,
+    patience: int = 300,
+    warm_up: int = 100,
+    use_scheduler: bool = True,
+    device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    output: str = "training.png",
+    checkpoint: Optional[str] = None,
+):
+    """Train a Neural Quantum Embedding model and save loss plots.
+
+    Parameters mirror the command line options exposed by ``train_nqe.py``.
+    ``hidden_dims`` defaults to ``[16, 16]`` when not provided.  The training
+    history dictionary returned by ``train_with_early_stopping`` is returned
+    along with the trained model instance.  If ``checkpoint`` is supplied, the
+    model's ``state_dict`` is saved there in PyTorch's ``.pt`` format.
+    """
+
+    if hidden_dims is None:
+        hidden_dims = [16, 16]
+
+    X_train, Y_train, X_test, Y_test = load_dataset(dataset, pca_dim)
+
+    q_layer = QuantumEmbeddingLayer(ZZFeatureMap, n_qubits=n_qubits)
+    model_kwargs = {
+        "in_dims": pca_dim,
+        "n_qubits": n_qubits,
+        "n_layers": n_layers,
+        "hidden_dims": hidden_dims,
+        "q_embedding": q_layer,
+    }
+    if model == "nqe":
+        model_cls = NQE
+    elif model == "nqe_big":
+        model_cls = NQE_BIG
+    else:
+        model_cls = UCNQE
+        model_kwargs["mode"] = uc_mode
+    model_inst = model_cls(**model_kwargs)
+
+    optimizer = torch.optim.Adam(model_inst.parameters(), lr=lr)
+    train_loader = build_train_loader(
+        X_train, Y_train, batch_size, n=max_steps + 1
+    )
+    val_loader = build_validation_loader(X_test, Y_test, batch_size)
+
+    hist = train_with_early_stopping(
+        model_inst,
+        train_loader,
+        val_loader,
+        optimizer,
+        max_steps=max_steps,
+        device=device,
+        validate_every=validate_every,
+        patience=patience,
+        warm_up=warm_up,
+        scheduler=use_scheduler,
+    )
+
+    steps = range(len(hist["train_loss"]))
+    val_steps = list(range(0, len(hist["train_loss"]), validate_every))[: len(hist["val_loss"])]
+
+    plt.figure()
+    plt.plot(steps, hist["train_loss"], label="train loss")
+    plt.plot(val_steps, hist["val_loss"], label="val loss")
+    plt.xlabel("training step")
+    plt.ylabel("MSE loss")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output)
+    plt.close()
+    print(f"Training plot saved to {output}")
+
+    if checkpoint:
+        torch.save(model_inst.state_dict(), checkpoint)
+        print(f"Model checkpoint saved to {checkpoint}")
+
+    return hist, model_inst
+
+
+def main():
+    args = parse_args()
+    train_model(
+        dataset=args.dataset,
+        model=args.model,
+        pca_dim=args.pca_dim,
+        uc_mode=args.uc_mode,
+        n_qubits=args.n_qubits,
+        n_layers=args.n_layers,
+        hidden_dims=args.hidden_dims,
+        batch_size=args.batch_size,
+        lr=args.lr,
+        max_steps=args.max_steps,
+        validate_every=args.validate_every,
+        patience=args.patience,
+        warm_up=args.warm_up,
+        use_scheduler=not args.no_scheduler,
+        device=args.device,
+        output=args.output,
+        checkpoint=args.checkpoint,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- return trained model from `train_model` for downstream analysis
- compute trace distance, Hilbert–Schmidt distance, and quantum kernel alignment in bulk training sweeps
- document new metric comparison plots in the README

## Testing
- `python -m pytest`
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68c0504ba42483259b090a0f97dc5d7c